### PR TITLE
Remove unnecessary require statements which cause Node 0.7.x to crash

### DIFF
--- a/q-io.js
+++ b/q-io.js
@@ -4,8 +4,6 @@
  * @module
  */
 
-var FS = require("fs"); // node
-var SYS = require("sys"); // node
 var Q = require("q"); // q package
 
 /*whatsupdoc*/


### PR DESCRIPTION
It seems q-io requires 'fs' and 'sys', but neither are needed.  The require call to 'sys' throws an exception in Node 0.7.x (see below).  Removing these two require statements seems like a stable fix and prevents the error.

I can npm link my local q-io into q-fs, but that doesn't solve the problem for everyone, hence this pull request.

In a project using q-fs:

```
$ node -v
v0.7.1

$ node .

node.js:218
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: The "sys" module is now called "util".
    at sys.js:1:69
    at NativeModule.compile (node.js:557:5)
    at Function.require (node.js:525:18)
    at Function._load (module.js:298:25)
    at Module.require (module.js:359:17)
    at require (module.js:370:17)
    at Object.<anonymous> (/myproject/node_modules/q-fs/node_modules/q-io/q-io.js:8:11)
    at Module._compile (module.js:434:26)
    at Object..js (module.js:452:10)
    at Module.load (module.js:353:32)
```
