### PR TITLE
slurp() should respect charset argument of Reader constructor

### DIFF
--- a/q-io.js
+++ b/q-io.js
@@ -51,7 +51,12 @@ exports.Reader = function (_stream, charset) {
     });
 
     function slurp() {
-        var result = join(chunks, charset);
+        var result;
+        if (charset) {
+            result = chunks.join("");
+        } else {
+            result = join(chunks);
+        }
         chunks.splice(0, chunks.length);
         return result;
     }


### PR DESCRIPTION
It fixes bug introduced in 814d4ccc9bcd804e94eb10ff7fa6cc44ffed3242
