### PR TITLE
Add Stats.size()

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -409,6 +409,10 @@ exports.update = function (exports, workingDirectory) {
     Stats.prototype.lastAccessed = function () {
         return Date.parse(this.node.atime);
     };
+    
+    Stats.prototype.size = function () {
+        return this.node.size;
+    };
 
 }
 


### PR DESCRIPTION
I added a `size()` function to the `Stats` class that returns the inner `node.size`.

Other node [`Stats` properties](http://nodejs.org/api/fs.html#fs_class_fs_stats), such as `mode` and `nlink`, are still not directly exposed.
