### PR TITLE
Change date methods to return Dates

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -403,11 +403,11 @@ exports.update = function (exports, workingDirectory) {
     });
 
     Stats.prototype.lastModified = function () {
-        return Date.parse(this.node.mtime);
+        return new Date(this.node.mtime);
     };
 
     Stats.prototype.lastAccessed = function () {
-        return Date.parse(this.node.atime);
+        return new Date(this.node.atime);
     };
 
 }

--- a/fs.js
+++ b/fs.js
@@ -289,11 +289,11 @@ exports.chmod = function (path, mode) {
 };
 
 exports.lastModified = function (path) {
-    return exports.stat(path).get('mtime').then(Date.parse);
+    return exports.stat(path).invoke('lastModified');
 };
 
 exports.lastAccessed = function (path) {
-    return exports.stat(path).get('atime').then(Date.parse);
+    return exports.stat(path).invoke('lastAccessed');
 };
 
 exports.canonical = function (path) {


### PR DESCRIPTION
The `lastAccessed()` and `lastModified()` methods should return `Date` instances, not numbers.

Counter-intuitively, `Date.parse()` returns a number, not a `Date`.
