### PR TITLE
Add failing tests for relativeFromDirectory

### DIFF
--- a/test/fs/all.js
+++ b/test/fs/all.js
@@ -5,6 +5,8 @@ exports['test mock/read'] = require('./mock/read');
 exports['test mock/subtree'] = require('./mock/subtree');
 exports['test root mock'] = require('./root');
 exports['test partial'] = require("./partial");
+exports['test common'] = require("./common");
+
 
 if (module == require.main)
     require('test').run(exports)

--- a/test/fs/common.js
+++ b/test/fs/common.js
@@ -1,0 +1,28 @@
+"use strict";
+/*jshint node:true */
+
+var FS = require("../../fs");
+
+exports['test relativeFromDirectory'] = function (ASSERT, done) {
+
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a/b"), "", "same");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a/b"), "", "same, source trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a/b/"), "", "same, target trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a/b/"), "", "same, both trailing slash");
+
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a/b/c"), "c", "child");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a/b/c"), "c", "child, source trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a/b/c/"), "c", "child, target trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a/b/c/"), "c", "child, both trailing slash");
+
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a"), "..", "parent");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a"), "..", "parent, source trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b", "/a/"), "..", "parent, target trailing slash");
+    ASSERT.equal(FS.relativeFromDirectory("/a/b/", "/a/"), "..", "parent, both trailing slash");
+
+    done();
+};
+
+if (require.main === module) {
+    require("test").run(exports);
+}


### PR DESCRIPTION
There's some funkyness going on where only the first few fs tests are running. Changing the order changes which tests run :/. These tests can be run directly with `node test/fs/common.js`
