### PR TITLE
Normalize spec paths for Windows test runs

### DIFF
--- a/spec/fs/boot-directory-spec.js
+++ b/spec/fs/boot-directory-spec.js
@@ -1,6 +1,6 @@
 
 var FS = require("../../fs-boot");
-var _n = FS.normal;
+var normalize = FS.normal;
 
 var specs = [
     {
@@ -17,7 +17,7 @@ var specs = [
     },
     {
         "from": "..",
-        "to": _n("../..")
+        "to": normalize("../..")
     },
     {
         "from": "../foo",
@@ -25,11 +25,11 @@ var specs = [
     },
     {
         "from": "/foo/bar",
-        "to": _n("/foo")
+        "to": normalize("/foo")
     },
     {
         "from": "/foo",
-        "to": _n("/")
+        "to": normalize("/")
     },
     {
         "from": "/",

--- a/spec/fs/boot-directory-spec.js
+++ b/spec/fs/boot-directory-spec.js
@@ -1,5 +1,6 @@
 
 var FS = require("../../fs-boot");
+var _n = FS.normal;
 
 var specs = [
     {
@@ -16,7 +17,7 @@ var specs = [
     },
     {
         "from": "..",
-        "to": "../.."
+        "to": _n("../..")
     },
     {
         "from": "../foo",
@@ -24,11 +25,11 @@ var specs = [
     },
     {
         "from": "/foo/bar",
-        "to": "/foo"
+        "to": _n("/foo")
     },
     {
         "from": "/foo",
-        "to": "/"
+        "to": _n("/")
     },
     {
         "from": "/",

--- a/spec/fs/mock/copy-tree-spec.js
+++ b/spec/fs/mock/copy-tree-spec.js
@@ -4,7 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
-var _n = FS.normal;
+var normalize = FS.normal;
 
 describe("copyTree", function () {
     it("should copy a tree", function () {
@@ -40,14 +40,14 @@ describe("copyTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                _n("a/b"),
-                _n("a/b/c"),
-                _n("a/b/c/d"),
-                _n("a/b/c/e"),
-                _n("a/f"),
-                _n("a/f/c"),
-                _n("a/f/c/d"),
-                _n("a/f/c/e")
+                normalize("a/b"),
+                normalize("a/b/c"),
+                normalize("a/b/c/d"),
+                normalize("a/b/c/e"),
+                normalize("a/f"),
+                normalize("a/f/c"),
+                normalize("a/f/c/d"),
+                normalize("a/f/c/e")
             ]);
         })
 

--- a/spec/fs/mock/copy-tree-spec.js
+++ b/spec/fs/mock/copy-tree-spec.js
@@ -4,6 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
+var _n = FS.normal;
 
 describe("copyTree", function () {
     it("should copy a tree", function () {
@@ -39,14 +40,14 @@ describe("copyTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                "a/b",
-                "a/b/c",
-                "a/b/c/d",
-                "a/b/c/e",
-                "a/f",
-                "a/f/c",
-                "a/f/c/d",
-                "a/f/c/e"
+                _n("a/b"),
+                _n("a/b/c"),
+                _n("a/b/c/d"),
+                _n("a/b/c/e"),
+                _n("a/f"),
+                _n("a/f/c"),
+                _n("a/f/c/d"),
+                _n("a/f/c/e")
             ]);
         })
 

--- a/spec/fs/mock/link-spec.js
+++ b/spec/fs/mock/link-spec.js
@@ -1,7 +1,7 @@
 
 require("../../lib/jasmine-promise");
 var MockFs = require("../../../fs-mock");
-var _n = require('../../../fs').normal;
+var normalize = require('../../../fs').normal;
 
 describe("link", function () {
     it("should", function () {
@@ -42,9 +42,9 @@ describe("link", function () {
             expect(content).toEqual([
                 ".",
                 "a",
-                _n("a/b"),
-                _n("a/b/c.txt"),
-                _n("a/b/d.txt")
+                normalize("a/b"),
+                normalize("a/b/c.txt"),
+                normalize("a/b/d.txt")
             ])
         })
 

--- a/spec/fs/mock/link-spec.js
+++ b/spec/fs/mock/link-spec.js
@@ -1,6 +1,7 @@
 
 require("../../lib/jasmine-promise");
 var MockFs = require("../../../fs-mock");
+var _n = require('../../../fs').normal;
 
 describe("link", function () {
     it("should", function () {
@@ -41,9 +42,9 @@ describe("link", function () {
             expect(content).toEqual([
                 ".",
                 "a",
-                "a/b",
-                "a/b/c.txt",
-                "a/b/d.txt"
+                _n("a/b"),
+                _n("a/b/c.txt"),
+                _n("a/b/d.txt")
             ])
         })
 

--- a/spec/fs/mock/make-tree-spec.js
+++ b/spec/fs/mock/make-tree-spec.js
@@ -4,7 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
-var _n = FS.normal;
+var normalize = FS.normal;
 
 describe("makeTree", function () {
     it("should make a branch of a tree", function () {
@@ -24,8 +24,8 @@ describe("makeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                _n("a/b"),
-                _n("a/b/c")
+                normalize("a/b"),
+                normalize("a/b/c")
             ]);
         })
 
@@ -62,9 +62,9 @@ describe("makeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                _n("a/b"),
-                _n("a/b/c"),
-                _n("a/b/c/d")
+                normalize("a/b"),
+                normalize("a/b/c"),
+                normalize("a/b/c/d")
             ]);
         })
     });

--- a/spec/fs/mock/make-tree-spec.js
+++ b/spec/fs/mock/make-tree-spec.js
@@ -4,6 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
+var _n = FS.normal;
 
 describe("makeTree", function () {
     it("should make a branch of a tree", function () {
@@ -23,8 +24,8 @@ describe("makeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                "a/b",
-                "a/b/c"
+                _n("a/b"),
+                _n("a/b/c")
             ]);
         })
 
@@ -61,9 +62,9 @@ describe("makeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                "a/b",
-                "a/b/c",
-                "a/b/c/d"
+                _n("a/b"),
+                _n("a/b/c"),
+                _n("a/b/c/d")
             ]);
         })
     });

--- a/spec/fs/mock/merge-spec.js
+++ b/spec/fs/mock/merge-spec.js
@@ -4,6 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
+var _n = FS.normal;
 
 describe("makeTree", function () {
     it("should make a branch of a tree", function () {
@@ -33,8 +34,8 @@ describe("makeTree", function () {
                 expect(list.sort()).toEqual([
                     ".",
                     "1",
-                    "1/2",
-                    "1/2/3",
+                    _n("1/2"),
+                    _n("1/2/3"),
                     "a",
                     "b",
                     "c",

--- a/spec/fs/mock/merge-spec.js
+++ b/spec/fs/mock/merge-spec.js
@@ -4,7 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
-var _n = FS.normal;
+var normalize = FS.normal;
 
 describe("makeTree", function () {
     it("should make a branch of a tree", function () {
@@ -34,8 +34,8 @@ describe("makeTree", function () {
                 expect(list.sort()).toEqual([
                     ".",
                     "1",
-                    _n("1/2"),
-                    _n("1/2/3"),
+                    normalize("1/2"),
+                    normalize("1/2/3"),
                     "a",
                     "b",
                     "c",

--- a/spec/fs/mock/remove-tree-spec.js
+++ b/spec/fs/mock/remove-tree-spec.js
@@ -4,6 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
+var _n = FS.normal;
 
 describe("removeTree", function () {
     it("should remove a tree", function () {
@@ -28,7 +29,7 @@ describe("removeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                "a/b"
+                _n("a/b")
             ]);
         })
 

--- a/spec/fs/mock/remove-tree-spec.js
+++ b/spec/fs/mock/remove-tree-spec.js
@@ -4,7 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
-var _n = FS.normal;
+var normalize = FS.normal;
 
 describe("removeTree", function () {
     it("should remove a tree", function () {
@@ -29,7 +29,7 @@ describe("removeTree", function () {
             expect(list).toEqual([
                 ".",
                 "a",
-                _n("a/b")
+                normalize("a/b")
             ]);
         })
 

--- a/spec/fs/mock/symbolic-link-spec.js
+++ b/spec/fs/mock/symbolic-link-spec.js
@@ -1,6 +1,7 @@
 
 require("../../lib/jasmine-promise");
 var MockFs = require("../../../fs-mock");
+var _n = require('../../../fs').normal;
 
 describe("symbolic link", function () {
     it("should", function () {
@@ -49,9 +50,9 @@ describe("symbolic link", function () {
             expect(content).toEqual([
                 ".",
                 "a",
-                "a/b",
-                "a/b/c.txt",
-                "a/b/d.txt"
+                _n("a/b"),
+                _n("a/b/c.txt"),
+                _n("a/b/d.txt")
             ])
         })
 

--- a/spec/fs/mock/symbolic-link-spec.js
+++ b/spec/fs/mock/symbolic-link-spec.js
@@ -1,7 +1,7 @@
 
 require("../../lib/jasmine-promise");
 var MockFs = require("../../../fs-mock");
-var _n = require('../../../fs').normal;
+var normalize = require('../../../fs').normal;
 
 describe("symbolic link", function () {
     it("should", function () {
@@ -50,9 +50,9 @@ describe("symbolic link", function () {
             expect(content).toEqual([
                 ".",
                 "a",
-                _n("a/b"),
-                _n("a/b/c.txt"),
-                _n("a/b/d.txt")
+                normalize("a/b"),
+                normalize("a/b/c.txt"),
+                normalize("a/b/d.txt")
             ])
         })
 


### PR DESCRIPTION
Specs with forward slashes in the expected results fail on Windows.  I'm using the "normal" function to change the expectations per-platform.

Tests pass on OSX and Windows.
