### PR TITLE
Fixed EOL character for Windows test runs

### DIFF
--- a/spec/fs/mock/move-spec.js
+++ b/spec/fs/mock/move-spec.js
@@ -4,6 +4,7 @@ require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
 var Mock = require("../../../fs-mock");
+var EOL = require('os').EOL;
 
 describe("move", function () {
     it("should move", function () {
@@ -51,7 +52,7 @@ describe("move", function () {
                 return mock.read("new-hello.txt");
             })
             .then(function (content) {
-                expect(content).toBe("Hello, World!\n");
+                expect(content).toBe("Hello, World!" + EOL);
             })
 
         });
@@ -138,7 +139,7 @@ describe("move", function () {
                 return mock.read("hello.txt");
             })
             .then(function (content) {
-                expect(content).toBe("Hello, World!\n");
+                expect(content).toBe("Hello, World!" + EOL);
             })
 
             // move!
@@ -164,7 +165,7 @@ describe("move", function () {
                 return mock.read("hello.txt");
             })
             .then(function (content) {
-                expect(content).toBe("Hello, World!\n");
+                expect(content).toBe("Hello, World!" + EOL);
             })
         });
 

--- a/spec/fs/mock/read-spec.js
+++ b/spec/fs/mock/read-spec.js
@@ -3,6 +3,7 @@
 require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
+var EOL = require('os').EOL;
 
 describe("read", function () {
     it("should read a file from a mock filesystem", function () {
@@ -14,7 +15,7 @@ describe("read", function () {
                 return mock.read("hello.txt");
             })
             .then(function (content) {
-                expect(content).toBe("Hello, World!\n");
+                expect(content).toBe("Hello, World!" + EOL);
             })
 
         });

--- a/spec/fs/mock/write-spec.js
+++ b/spec/fs/mock/write-spec.js
@@ -3,6 +3,7 @@
 require("../../lib/jasmine-promise");
 var Q = require("q");
 var FS = require("../../../fs");
+var EOL = require('os').EOL;
 
 describe("write", function () {
     it("should write a file to a mock filesystem", function () {
@@ -11,7 +12,7 @@ describe("write", function () {
         .then(function (mock) {
 
             return Q.fcall(function () {
-                return mock.write("hello.txt", "Goodbye!\n");
+                return mock.write("hello.txt", "Goodbye!" + EOL);
             })
             .then(function () {
                 return mock.isFile("hello.txt");


### PR DESCRIPTION
Specs with hardcoded "\n" expected at the end of files fail in Windows.  Fixed this using require('os').EOL.

Tests pass on OSX and Windows.
