### PR TITLE
In makeTree, if absolute use the given root

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -182,7 +182,7 @@ exports.update = function (exports, workingDirectory) {
         var parts = self.split(path);
         var at = [];
         if (self.isAbsolute(path))
-            at.push(self.ROOT);
+            at.push(parts.shift());
         return parts.reduce(function (parent, part) {
             return Q.when(parent, function () {
                 at.push(part);


### PR DESCRIPTION
Fixes Windows, where calling makeDirectory on a drive (e.g. "C:\")
fails with a permision error. This will cause the drive to be skipped
on Windows. "" will be skipped on *nix, which when joined with the
next part turns into "/", the same behaviour as before.
