### PR TITLE
Improve support for writing binray data

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -66,8 +66,12 @@ exports.update = function (exports, workingDirectory) {
             options.flags = flags;
             options.charset = charset;
         }
-        flags = "w" + (options.flags || "").replace(/[wb]/g, "");
-        if (content instanceof Buffer) {
+        flags = "w" + (options.flags || "").replace(/[w]/g, "");
+        if (flags.indexOf("b") !== -1) {
+            if (!(content instanceof Buffer)) {
+                content = new Buffer(content);
+            }
+        } else if (content instanceof Buffer) {
             flags += "b";
         }
         options.flags = flags;

--- a/writer.js
+++ b/writer.js
@@ -40,6 +40,9 @@ function Writer(_stream, charset) {
     self.write = function (content) {
         if (!_stream.writeable && !_stream.writable)
             return Q.reject(new Error("Can't write to non-writable (possibly closed) stream"));
+        if (_stream.encoding == "binary" && !(content instanceof Buffer)) {
+            content = new Buffer(content);
+        }
         if (!_stream.write(content)) {
             return drained.promise;
         } else {


### PR DESCRIPTION
In order to write binary data with q-io, the data must be either a string or a Buffer. However, when using q-io via q-connect over a websocket, you cannot send the data as string without having some conversion done. As Buffer is not exposed on the client side, the best way is to send it as a Bytes array.

This patch allow you to write binary data which is send as an array (or any other type the Buffer constructor support)

Note: This patch does not address any similar potential issue with reading binary data which need to be send back to the client via websocket.
