### PR TITLE
rerooted makeDirectory() failing

### DIFF
--- a/spec/fs/reroot-spec.js
+++ b/spec/fs/reroot-spec.js
@@ -1,0 +1,30 @@
+var FS = require("../../fs");
+
+require("../lib/jasmine-promise");
+
+describe("reroot", function () {
+
+    it("should still have makeDirectory()", function() {
+		return FS.reroot("/")
+		.then(function(fs) {
+			expect(fs.makeTree instanceof Function).toBe(true);
+			expect(fs.makeDirectory instanceof Function).toBe(true);
+		});
+    });
+
+	it("should have a makeDirectory() that creates within the attenuated root", function() {
+		var tmpdir = __dirname + '/tmp';
+		return FS.removeTree(tmpdir)
+		.then(function() {
+			return FS.makeTree(tmpdir)
+		}).then(function() {
+			return FS.reroot(tmpdir);
+		}).then(function(fs) {
+			return fs.makeDirectory('/foo');
+		}).then(function() {
+			return FS.isDirectory(tmpdir + '/foo');
+		}).then(function(isDir) {
+			if (!isDir) return Q.reject();
+		});
+	});
+});


### PR DESCRIPTION
Hey,

Following on from Issue #31, I've written a test (I couldn't find one for this behaviour) describing how I'm expecting it to work but it's currently failing like so:

```
$ jasmine-node spec/fs/reroot-spec.js 
.F

Failures:

  1) reroot should have a makeDirectory() that creates within the attenuated root
   Message:
     Error: Can't make directory "/foo"
   Stacktrace:
     Error: Can't make directory "/foo"
    at /home/dschoen/code/q-io/fs-root.js:92:19
    at /home/dschoen/code/q-io/node_modules/q/q.js:917:30
    at processImmediate [as _immediateCallback] (timers.js:317:15)
From previous event:
    at null.<anonymous> (/home/dschoen/code/q-io/spec/fs/reroot-spec.js:26:6)
    at jasmine.Block.execute (/home/dschoen/code/q-io/spec/lib/jasmine-promise.js:23:32)
    at jasmine.Queue.next_ (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2096:31)
    at jasmine.Queue.start (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2049:8)
    at jasmine.Spec.execute (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2376:14)
    at jasmine.Queue.next_ (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2096:31)
    at onComplete (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2092:18)
    at jasmine.Spec.finish (/usr/lib/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2350:5)

Finished in 0.046 seconds
2 tests, 3 assertions, 1 failure
```

I've started prodding the code to try to figure out what's going on and as far as I've gotten is that the attenuated `makeDirectory()` call is trying to attentuate the path before it exists, but I'm not quite sure where next to poke the code to make it do the right thing.

Partly just pushing through this half finished issue so you can double check the test and see if I'm trying to use it correctly?

Thanks for the speedy response to #31.

Cheers,
Dave
