### PR TITLE
Fixed some issue related to using a stream to write binary data passed as array

### DIFF
--- a/writer.js
+++ b/writer.js
@@ -22,6 +22,8 @@ function Writer(_stream, charset) {
 
     _stream.on("error", function (reason) {
         begin.reject(reason);
+        drained.reject(reason);
+        drained = Q.defer();
     });
 
     _stream.on("drain", function () {
@@ -40,7 +42,7 @@ function Writer(_stream, charset) {
     self.write = function (content) {
         if (!_stream.writeable && !_stream.writable)
             return Q.reject(new Error("Can't write to non-writable (possibly closed) stream"));
-        if (_stream.encoding == "binary" && !(content instanceof Buffer)) {
+        if (typeof content !== "string") {
             content = new Buffer(content);
         }
         if (!_stream.write(content)) {


### PR DESCRIPTION
This path fixes:
- Reject drained promise when a write error occurs
- Convert content to Buffer if content is not a string

Note: something in node.js must have changed which cause this "regression"
