### PR TITLE
Move Stats to fs-common and update mock to use

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -450,5 +450,35 @@ exports.update = function (exports, workingDirectory) {
         });
     };
 
+    exports.Stats = Stats;
+    function Stats(nodeStat) {
+        this.node = nodeStat;
+        this.size = nodeStat.size;
+    }
+
+    var stats = [
+        "isDirectory",
+        "isFile",
+        "isBlockDevice",
+        "isCharacterDevice",
+        "isSymbolicLink",
+        "isFIFO",
+        "isSocket"
+    ];
+
+    stats.forEach(function (name) {
+        Stats.prototype[name] = function () {
+            return this.node[name]();
+        };
+    });
+
+    Stats.prototype.lastModified = function () {
+        return new Date(this.node.mtime);
+    };
+
+    Stats.prototype.lastAccessed = function () {
+        return new Date(this.node.atime);
+    };
+
 }
 

--- a/fs-mock.js
+++ b/fs-mock.js
@@ -193,7 +193,7 @@ MockFs.prototype.stat = function (path) {
     var self = this;
     return Q.fcall(function () {
         path = self.absolute(path);
-        return self._root._walk(path)._follow(path);
+        return new self.Stats(self._root._walk(path)._follow(path));
     });
 };
 
@@ -443,6 +443,16 @@ FileNode.prototype = Object.create(Node.prototype);
 FileNode.prototype.isFile = function () {
     return true;
 };
+
+Object.defineProperty(FileNode.prototype, "size", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+        return this._chunks.reduce(function (size, chunk) {
+            return size += chunk.length;
+        }, 0);
+    }
+});
 
 function DirectoryNode(fs) {
     Node.call(this, fs);

--- a/fs.js
+++ b/fs.js
@@ -190,42 +190,13 @@ exports.stat = function (path) {
                 error.message = "Can't stat " + JSON.stringify(path) + ": " + error;
                 done.reject(error);
             } else {
-                done.resolve(new Stats(stat));
+                done.resolve(new self.Stats(stat));
             }
         });
     } catch (error) {
         done.reject(error);
     }
     return done.promise;
-};
-
-var Stats = function (nodeStat) {
-    this.node = nodeStat;
-    this.size = nodeStat.size;
-};
-
-var stats = [
-    "isDirectory",
-    "isFile",
-    "isBlockDevice",
-    "isCharacterDevice",
-    "isSymbolicLink",
-    "isFIFO",
-    "isSocket"
-];
-
-stats.forEach(function (name) {
-    Stats.prototype[name] = function () {
-        return this.node[name]();
-    };
-});
-
-Stats.prototype.lastModified = function () {
-    return new Date(this.node.mtime);
-};
-
-Stats.prototype.lastAccessed = function () {
-    return new Date(this.node.atime);
 };
 
 exports.statLink = function (path) {

--- a/spec/fs/mock/stat-spec.js
+++ b/spec/fs/mock/stat-spec.js
@@ -1,0 +1,26 @@
+"use strict";
+
+require("../../lib/jasmine-promise");
+var Q = require("q");
+var FS = require("../../../fs");
+/*global describe,it,expect */
+
+describe("stat", function () {
+    it("should return a Stats object", function () {
+        return FS.mock(FS.join(__dirname, "fixture"))
+        .then(function (mock) {
+            return mock.stat("hello.txt");
+        })
+        .then(function (stat) {
+            expect(stat.node).toBeDefined();
+            expect(stat.size).toBeDefined();
+            expect(stat.size).toBeGreaterThan(0);
+            expect(stat.isDirectory()).toBe(false);
+            expect(stat.isFile()).toBe(true);
+        });
+    });
+
+
+
+});
+


### PR DESCRIPTION
I've used `Object.defineProperty` for the first time, but `Object.create` was already being used so I don't think this introduces any new incompatibility.
