### PR TITLE
Support HTTP / HTTPS agent

### DIFF
--- a/http.js
+++ b/http.js
@@ -281,7 +281,7 @@ exports.request = function (request) {
             "path": request.path || "/",
             "method": request.method || "GET",
             "headers": headers,
-            "agent": request.agent || undefined
+            "agent": request.agent
         }, function (_response) {
             deferred.resolve(exports.ClientResponse(_response, request.charset));
             _response.on("error", function (error) {

--- a/http.js
+++ b/http.js
@@ -280,7 +280,8 @@ exports.request = function (request) {
             "port": request.port || (ssl ? 443 : 80),
             "path": request.path || "/",
             "method": request.method || "GET",
-            "headers": headers
+            "headers": headers,
+            "agent": request.agent || undefined
         }, function (_response) {
             deferred.resolve(exports.ClientResponse(_response, request.charset));
             _response.on("error", function (error) {


### PR DESCRIPTION
There are a few use cases of using a HTTP or HTTPS agent, including:
- Use a custom pool of sockets
- Allow use of self-signed certificates in HTTPS connections
- Add SSL client certificates and private keys

The certificate use is a very useful scenario when doing development or connecting to a self-signed HTTPS server.

References:
HTTP Agent: http://nodejs.org/api/http.html#http_class_http_agent
HTTPS Agent: http://nodejs.org/api/https.html#https_class_https_agent
