### PR TITLE
Tolerate . in FS.makeTree

### DIFF
--- a/fs-common.js
+++ b/fs-common.js
@@ -235,7 +235,7 @@ exports.update = function (exports, workingDirectory) {
         return parts.reduce(function (parent, part) {
             return Q.when(parent, function () {
                 at.push(part);
-                var parts = self.join(at);
+                var parts = self.join(at) || ".";
                 var made = self.makeDirectory(parts, mode);
                 return Q.when(made, null, function rejected(error) {
                     // throw away errors for already made directories

--- a/spec/fs/make-tree-spec.js
+++ b/spec/fs/make-tree-spec.js
@@ -82,5 +82,11 @@ describe("makeTree", function () {
             return FS.removeTree("a");
         })
     });
+
+    it("should tolerate .", function () {
+        return Q.fcall(function () {
+            return FS.makeTree(".");
+        })
+    });
 });
 


### PR DESCRIPTION
The `normal` function exported by `fs-boot.js` consumes all `.` (so `normal('.')` returns `''`).  If `makeTree` is called with `'.'`, this is reduced to `''` before being passed to `fs.mkdir` (which fails).

It looks like there would be a number of places this could be addressed.  472d23c88f73af206e1d00a5930abb20d6754187 is a minimal change to make `makeTree` tolerant to `'.'`.

I'm running into this case when calling `FS.makeTree(path.dirname(filepath))` (see tschaub/grunt-gh-pages#17).
