### PR TITLE
Fix write.close() returning before all data is flushed on disk

### DIFF
--- a/writer.js
+++ b/writer.js
@@ -80,7 +80,11 @@ function Writer(_stream, charset) {
     self.close = function () {
         _stream.end();
         drained.resolve(); // we will get no further drain events
-        return finished.promise; // closing not explicitly observable
+        if(process.version.split('.')[1] < 10){ // closing not explicitly observable
+            return Q.resolve() // just resolve for old Streams
+        } else {
+            return finished.promise;
+        }
     };
 
     /***

--- a/writer.js
+++ b/writer.js
@@ -19,6 +19,7 @@ function Writer(_stream, charset) {
 
     var begin = Q.defer();
     var drained = Q.defer();
+    var finished = Q.defer();
 
     _stream.on("error", function (reason) {
         begin.reject(reason);
@@ -30,6 +31,12 @@ function Writer(_stream, charset) {
         begin.resolve(self);
         drained.resolve();
         drained = Q.defer();
+    });
+    
+    _stream.on("finish", function () {
+        begin.resolve(self);
+        drained.resolve();
+        finished.resolve();
     });
 
     /***
@@ -73,7 +80,7 @@ function Writer(_stream, charset) {
     self.close = function () {
         _stream.end();
         drained.resolve(); // we will get no further drain events
-        return Q.resolve(); // closing not explicitly observable
+        return finished.promise; // closing not explicitly observable
     };
 
     /***

--- a/writer.js
+++ b/writer.js
@@ -11,33 +11,35 @@ var Q = require("q");
  * text writer.
  */
 module.exports = Writer;
+
+/**
+ * Check if we have a newer Stream API 
+ *
+ * @returns {Boolean} 
+ */
+function supportsFinish () {
+    return process.version.split('.')[1] >= 10;
+}
+
+
 function Writer(_stream, charset) {
     var self = Object.create(Writer.prototype);
 
     if (charset && _stream.setEncoding) // TODO complain about inconsistency
         _stream.setEncoding(charset);
 
-    var begin = Q.defer();
     var drained = Q.defer();
-    var finished = Q.defer();
 
     _stream.on("error", function (reason) {
-        begin.reject(reason);
         drained.reject(reason);
         drained = Q.defer();
     });
 
     _stream.on("drain", function () {
-        begin.resolve(self);
         drained.resolve();
         drained = Q.defer();
     });
     
-    _stream.on("finish", function () {
-        begin.resolve(self);
-        drained.resolve();
-        finished.resolve();
-    });
 
     /***
      * Writes content to the stream.
@@ -78,12 +80,24 @@ function Writer(_stream, charset) {
      * flushing, and closed.
      */
     self.close = function () {
+        var finished = false;
+        
+        if(supportsFinish()){ // new Streams, listen for `finish` event
+            finished = Q.defer();
+            _stream.on("finish", function () {
+                finished.resolve();
+            });
+            _stream.on("error", function (reason) {
+                finished.reject(reason);
+            });
+        }
+        
         _stream.end();
         drained.resolve(); // we will get no further drain events
-        if(process.version.split('.')[1] < 10){ // closing not explicitly observable
-            return Q.resolve() // just resolve for old Streams
-        } else {
+        if(finished){ // closing not explicitly observable
             return finished.promise;
+        } else {
+            return Q.resolve() // just resolve for old Streams
         }
     };
 


### PR DESCRIPTION
writer.close() was returning (resolving) before all data was flushed on disk due to missing 'finish' event listener: 
http://nodejs.org/api/stream.html#stream_event_finish
