### PR TITLE
Fix node version check

### DIFF
--- a/writer.js
+++ b/writer.js
@@ -12,7 +12,7 @@ var Q = require("q");
  */
 module.exports = Writer;
 
-var version = process.version.split('.');
+var version = process.versions.node.split('.');
 var supportsFinish = version[0] >= 0 && version[1] >= 10;
 
 function Writer(_stream, charset) {


### PR DESCRIPTION
`process.version.split('.')[0]` was giving 'v0' so `supportsFinish` was always false.
