### PR TITLE
Use SymbolicLink rather than Symlink in API

### DIFF
--- a/deprecate.js
+++ b/deprecate.js
@@ -1,0 +1,51 @@
+/**
+ * @module deprecate
+ */
+
+/**
+ * Prints out a deprecation warning to the console.warn with the format:
+ * `name` is deprecated, use `alternative` instead.
+ * It can also print out a stack trace with the line numbers.
+ * @param {String} name - Name of the thing that is deprecated.
+ * @param {String} alternative - Name of alternative that should be used instead.
+ * @param {Number} [stackTraceLimit] - depth of the stack trace to print out. Set to falsy value to disable stack.
+ */
+exports.deprecationWarning = function deprecationWarning(name, alternative, stackTraceLimit) {
+    if (stackTraceLimit) {
+        var depth = Error.stackTraceLimit;
+        Error.stackTraceLimit = stackTraceLimit;
+    }
+    if (typeof console !== "undefined" && typeof console.warn === "function") {
+        var stack = (stackTraceLimit ? new Error("").stack : "") ;
+        if(alternative) {
+            console.warn(name + " is deprecated, use " + alternative + " instead.", stack);
+        } else {
+            //name is a complete message
+            console.warn(name, stack);
+        }
+    }
+    if (stackTraceLimit) {
+        Error.stackTraceLimit = depth;
+    }
+}
+
+/**
+ * Provides a function that can replace a method that has been deprecated.
+ * Prints out a deprecation warning to the console.warn with the format:
+ * `name` is deprecated, use `alternative` instead.
+ * It will also print out a stack trace with the line numbers.
+ * @param {Object} scope - The object that will be used as the `this` when the `deprecatedFunction` is applied.
+ * @param {Function} deprecatedFunction - The function object that is deprecated.
+ * @param {String} name - Name of the method that is deprecated.
+ * @param {String} alternative - Name of alternative method that should be used instead.
+ * @returns {Function} deprecationWrapper
+ */
+exports.deprecateMethod = function deprecate(scope, deprecatedFunction, name, alternative) {
+    var deprecationWrapper = function () {
+        // stackTraceLimit = 3 // deprecationWarning + deprecate + caller of the deprecated method
+        deprecationWarning(name, alternative, 3);
+        return deprecatedFunction.apply(scope ? scope : this, arguments);
+    };
+    deprecationWrapper.deprecatedFunction = deprecatedFunction;
+    return deprecationWrapper;
+}

--- a/http-apps/fs.js
+++ b/http-apps/fs.js
@@ -52,7 +52,7 @@ exports.FileTree = function (root, options) {
         return Q.when(root, function (root) {
             var path = fs.join(root, request.pathInfo.slice(1));
             return Q.when(fs.canonical(path), function (canonical) {
-                if (!fs.contains(root, canonical) && !options.followInsecureSymlinks)
+                if (!fs.contains(root, canonical) && !options.followInsecureSymbolicLinks)
                     return options.notFound(request, response);
                 if (path !== canonical && options.redirectSymbolicLinks)
                     return redirect(request, fs.relativeFromFile(path, canonical));

--- a/http-apps/fs.js
+++ b/http-apps/fs.js
@@ -7,6 +7,7 @@ var StatusApps = require("./status");
 var RedirectApps = require("./redirect");
 var Negotiation = require("./negotiate");
 var HtmlApps = require("./html");
+var Deprecate = require("../deprecate");
 
 /**
  * @param {String} path
@@ -52,6 +53,11 @@ exports.FileTree = function (root, options) {
         return Q.when(root, function (root) {
             var path = fs.join(root, request.pathInfo.slice(1));
             return Q.when(fs.canonical(path), function (canonical) {
+                //TODO remove for 2.0.0
+                if (options.followInsecureSymlinks) {
+                    Deprecate.deprecationWarning("followInsecureSymlinks", "followInsecureSymbolicLinks");
+                    options.followInsecureSymbolicLinks = true;
+                }
                 if (!fs.contains(root, canonical) && !options.followInsecureSymbolicLinks)
                     return options.notFound(request, response);
                 if (path !== canonical && options.redirectSymbolicLinks)

--- a/spec/http-apps/symbolic-link-spec.js
+++ b/spec/http-apps/symbolic-link-spec.js
@@ -1,0 +1,110 @@
+/*global __dirname*/
+require("../lib/jasmine-promise");
+var Http = require("../../http");
+var Apps = require("../../http-apps");
+var FS = require("../../fs");
+var Mock = require("../../fs-mock");
+
+describe("FileTree followInsecureSymbolicLinks", function () {
+    var testApp;
+    function makeApp(followInsecureSymbolicLinks) {
+        var fixture = FS.join(module.directory || __dirname, "fixtures");
+        return FS.mock(fixture)
+        .then(function (mockFS) {
+            return FS.merge([ mockFS, Mock({ "6789/0123.txt": "0123\n" })]);
+        })
+        .then(function (mockFS) {
+            return mockFS.symbolicCopy("6789", FS.join("9012","linkedDir"), "directory").thenResolve(mockFS);
+        })
+        .then(function (mockFS) {
+            return mockFS.symbolicCopy( FS.join("6789","0123.txt"), FS.join("9012","linkedFile.txt"), "file").thenResolve(mockFS);
+        })
+        .then(function (mockFS) {
+            return new Apps.Chain()
+            .use(Apps.ListDirectories)
+            .use(function () {
+                return Apps.FileTree(FS.join("/","9012"), {fs: mockFS, followInsecureSymbolicLinks: followInsecureSymbolicLinks});
+            })
+            .end()
+        }).then(function (app) {
+            return Http.Server(app).listen(0)
+        });
+    };
+
+    describe("if false", function () {
+        beforeEach(function () {
+            testApp = makeApp(false)
+        });
+        it("should not follow symbolic links to directories", function () {
+            return testApp.then(function (server) {
+                var port = server.address().port;
+                return Http.read({
+                    url: "http://127.0.0.1:" + port + "/linkedDir/",
+                    headers: {
+                        accept: "text/plain"
+                    },
+                    charset: 'utf-8'
+                })
+                .then(null, function (error) {
+                    expect(error.response.status).toEqual(404);
+                })
+                .finally(server.stop);
+            });
+        });
+        it("should not follow symbolic links to files", function () {
+            return testApp.then(function (server) {
+                var port = server.address().port;
+                return Http.read({
+                    url: "http://127.0.0.1:" + port + "/linkedFile.txt",
+                    headers: {
+                        accept: "text/plain"
+                    },
+                    charset: 'utf-8'
+                })
+                .then(null, function (error) {
+                    expect(error.response.status).toEqual(404);
+                })
+                .finally(server.stop);
+            });
+        });
+    });
+
+    describe("if true", function () {
+        beforeEach(function () {
+            testApp = makeApp(true)
+        });
+        it("should follow symbolic links to directories", function () {
+            return testApp.then(function (server) {
+                var port = server.address().port;
+                return Http.read({
+                    url: "http://127.0.0.1:" + port + "/linkedDir/",
+                    headers: {
+                        accept: "text/plain"
+                    },
+                    charset: 'utf-8'
+                })
+                .then(function (content) {
+                    expect(content).toEqual("0123.txt\n");
+                })
+                .finally(server.stop);
+            });
+        });
+        it("should follow symbolic links to files", function () {
+            return testApp.then(function (server) {
+                var port = server.address().port;
+                return Http.read({
+                    url: "http://127.0.0.1:" + port + "/linkedFile.txt",
+                    headers: {
+                        accept: "text/plain"
+                    },
+                    charset: 'utf-8'
+                })
+                .then(function (content) {
+                    expect(content).toEqual("0123\n");
+                })
+                .finally(server.stop);
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Rename followInsecureSymlinks to followInsecureSymbolicLinks. This
now matches what is writhe in the readme and release notes.

https://github.com/kriskowal/q-io/blob/master/README.md#filetreepath-options--application
https://github.com/kriskowal/q-io/blob/master/CHANGES#L55
