### PR TITLE
End promise chain

### DIFF
--- a/http.js
+++ b/http.js
@@ -268,7 +268,7 @@ exports.request = function (request) {
                     _request.end();
                 });
             });
-        });
+        }).done();
 
         return deferred.promise;
     });


### PR DESCRIPTION
Errors around the request body processing will not be thrown as there is currently a missing `done()` at the end of a promise chain.
