### PR TITLE
This closes kriskowal/q-io/issues/77. Instead of host the hostname is pa...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 .coverage_data
 cover_html
+/.project

--- a/http.js
+++ b/http.js
@@ -235,13 +235,13 @@ exports.normalizeRequest = function (request) {
     }
     if (request.url) {
         var url = URL.parse(request.url);
-        request.host = url.hostname;
+        request.hostname = url.hostname;
         request.port = url.port;
         request.ssl = url.protocol === "https:";
         request.method = request.method || "GET";
         request.path = (url.pathname || "") + (url.search || "");
         request.headers = request.headers || {};
-        request.headers.host = url.hostname; // FIXME name consistency
+        request.headers.host = url.host;
     }
     return request;
 };
@@ -280,11 +280,10 @@ exports.request = function (request) {
         var http = ssl ? HTTPS : HTTP;
 
         var headers = request.headers || {};
-
         headers.host = headers.host || request.host;
 
         var _request = http.request({
-            "host": request.host,
+            "hostname": request.hostname,
             "port": request.port || (ssl ? 443 : 80),
             "path": request.path || "/",
             "method": request.method || "GET",


### PR DESCRIPTION
This closes kriskowal/q-io/issues/77. Instead of host the hostname is passed to http.request and headers.host is now the host, not hostname.

Background info:
- hostname: To support url.parse() hostname is preferred over host. Source: http://nodejs.org/api/http.html#http_http_request_options_callback
- host should include port number. Source: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
