### PR TITLE
Fixes #88 - Adds HTTP Basic authentication when using "username:password@host.com" URL syntax

### DIFF
--- a/http.js
+++ b/http.js
@@ -242,6 +242,13 @@ exports.normalizeRequest = function (request) {
         request.path = (url.pathname || "") + (url.search || "");
         request.headers = request.headers || {};
         request.headers.host = url.hostname; // FIXME name consistency
+
+        if(url.auth) {
+            request.auth = url.auth;
+            if(!request.headers['Authorization']) {
+                request.headers['Authorization']='Basic ' + new Buffer(url.auth).toString('base64');
+            }
+        }
     }
     return request;
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "IO using Q promises",
   "homepage": "http://github.com/kriskowal/q-io/",
   "author": "Kris Kowal <kris@cixar.com> (http://github.com/kriskowal/)",
+  "contributors" : [
+    "Andreas Pizsa (http://github.com/AndreasPizsa/)"
+  ],
   "bugs": {
     "mail": "kris@cixar.com",
     "url": "http://github.com/kriskowal/q-io/issues"

--- a/spec/http/basic-spec.js
+++ b/spec/http/basic-spec.js
@@ -91,6 +91,23 @@ describe("http server and client", function () {
         .finally(server.stop)
     });
 
+    it('should set correct HTTP Basic authentication headers when username and password are passed in the URL',function(){
+        request = HTTP.normalizeRequest('http://username:password@www.google.com/');
+        expect(request.auth).toBe('username:password');
+        expect(request.headers['Authorization']).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+    });
 
+    it('should successfully access resources that require HTTP Basic authentication when using the username:password@host.com URL syntax', function(){
+        // This tries to access a public resource, see http://test.webdav.org/
+        //
+        // The resource is password protected, but there's no content behind it
+        // so we will actually receive a 404; that's ok though as at least it's
+        // a well-defined and expected status.
+        return HTTP.request('http://user1:user1@test.webdav.org/auth-basic/')
+        .then(function(response){
+            expect(response.status).not.toBe(401);
+            expect(response.status).toBe(404);
+        })
+    });
 });
 


### PR DESCRIPTION
Adds HTTP Basic authentication when using "username:password@host.com" URL syntax
Added functionality
Added test cases
Added credits to package.js contributors
