### PR TITLE
Removed duplication in Content App

### DIFF
--- a/http-apps/content.js
+++ b/http-apps/content.js
@@ -13,14 +13,8 @@ var URL = require("url2");
  * @returns {App} a Q-JSGI app
  */
 exports.Content = function (body, contentType, status) {
-    return function (request, response) {
-        return {
-            "status": status || 200,
-            "headers": {
-                "content-type": contentType || "text/plain"
-            },
-            "body": body || ""
-        };
+    return function () {
+        return exports.content(body, contentType, status);
     };
 };
 


### PR DESCRIPTION
It also was failing when non-empty string is passed. For example:

``` js
var http = require('./http');
var Apps = require('./http-apps');
var app = Apps.Content("hello");
http.Server(app).listen(3000);
```

results in

```
TypeError: Object hello has no method 'forEach'
```
