### PR TITLE
Default qualifier accepts all valid statuses.

### DIFF
--- a/http.js
+++ b/http.js
@@ -369,7 +369,7 @@ exports.request = function (request) {
  * status code is not exactly 200.  The reason for the
  * rejection is the full response object.
  */
-validStatuses = /(2\d{2,2}|304)/;
+var validStatuses = /(2\d{2,2}|304)/;
 exports.read = function (request, qualifier) {
     qualifier = qualifier || function (response) {
         return validStatuses.test(response.status);

--- a/http.js
+++ b/http.js
@@ -369,9 +369,10 @@ exports.request = function (request) {
  * status code is not exactly 200.  The reason for the
  * rejection is the full response object.
  */
+validStatuses = /(2\d{2,2}|304)/;
 exports.read = function (request, qualifier) {
     qualifier = qualifier || function (response) {
-        return response.status === 200;
+        return validStatuses.test(response.status);
     };
     return Q.when(exports.request(request), function (response) {
         if (!qualifier(response)){


### PR DESCRIPTION
Fixes #120.

Note that this fix accepts all 2xx responses (which are always defined as success) and a 304 response (which is defined as a success whenever certain headers are set).

This is a breaking change, and I advise at least a minor version upgrade.
