### PR TITLE
Altered request check for agent to allow agent to equal false

### DIFF
--- a/http.js
+++ b/http.js
@@ -319,7 +319,7 @@ exports.request = function (request) {
             auth: request.auth // Generates the appropriate header
         };
 
-        if (request.agent != undefined) {
+        if (request.agent !== undefined) {
             requestOptions.agent = request.agent;
         }
 

--- a/http.js
+++ b/http.js
@@ -319,7 +319,7 @@ exports.request = function (request) {
             auth: request.auth // Generates the appropriate header
         };
 
-        if (request.agent) {
+        if (request.agent != undefined) {
             requestOptions.agent = request.agent;
         }
 


### PR DESCRIPTION
Setting the agent to false is a way to ignore Agent pooling (as explained [here](http://stackoverflow.com/questions/12060869/why-is-node-js-only-processing-six-requests-at-a-time) ), however this would be filtered out by the existing check.
