### PR TITLE
Replace tilde with caret in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
     "url": "http://github.com/kriskowal/q-io.git"
   },
   "dependencies": {
-    "q": "~1.0.1",
-    "qs": "~1.2.1",
-    "url2": "~0.0.0",
-    "mime": "~1.2.11",
-    "mimeparse": "~0.1.4",
-    "collections": "~0.2.0"
+    "q": "^1.0.1",
+    "qs": "^1.2.1",
+    "url2": "^0.0.0",
+    "mime": "^1.2.11",
+    "mimeparse": "^0.1.4",
+    "collections": "^0.2.0"
   },
   "devDependencies": {
-    "jshint": "~0.9.1",
-    "cover": "~0.2.8",
-    "jasmine-node": "~1.7",
-    "opener": "~1.3"
+    "jshint": "^0.9.1",
+    "cover": "^0.2.8",
+    "jasmine-node": "^1.7",
+    "opener": "^1.3"
   },
   "scripts": {
     "test": "jasmine-node spec",


### PR DESCRIPTION
Original description:

> I tried to upgrade my q from 1.0.1 to 1.1.1 but now npm forces q-io (sibling module) to install it's own version of q@1.0.1 and refuses to use my app-level q@1.1.1. According to semver, this is not breaking change and should be supported.

See also: [Difference between tilde(~) and caret(^) in package.json](http://stackoverflow.com/questions/22343224/difference-between-tilde-and-caret-in-package-json)
