### PR TITLE
 http.request should accept the full request object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 .coverage_data
 cover_html
+npm-debug.log

--- a/http.js
+++ b/http.js
@@ -308,22 +308,13 @@ exports.request = function (request) {
         var deferred = Q.defer();
         var http = request.ssl ? HTTPS : HTTP;
 
-        var requestOptions = {
-            hostname: request.hostname,
-            port: request.port || (request.ssl ? 443 : 80),
-            localAddress: request.localAddress,
-            socketPath: request.socketPath,
-            method: request.method,
-            path: request.path,
-            headers: request.headers,
-            auth: request.auth // Generates the appropriate header
-        };
+        request.port = request.port || (request.ssl ? 443 : 80);
 
         if (request.agent !== undefined) {
-            requestOptions.agent = request.agent;
+          request.agent = request.agent;
         }
 
-        var _request = http.request(requestOptions, function (_response) {
+        var _request = http.request(request, function (_response) {
             deferred.resolve(exports.ClientResponse(_response, request.charset));
             _response.on("error", function (error) {
                 // TODO find a better way to channel
@@ -408,4 +399,3 @@ exports.ClientResponse = function (_response, charset) {
         return response;
     });
 };
-


### PR DESCRIPTION
Pass the whole request object and not filter it by using `requestOptions`

We are trying to proxy the request.host, that is the main aim of this. 
