### PR TITLE
Remove collections dependency and es6-set instead

### DIFF
--- a/coverage-report.js
+++ b/coverage-report.js
@@ -1,5 +1,3 @@
-
-require("collections/shim");
 var Q = require("q");
 var FS = require("./fs");
 
@@ -22,7 +20,8 @@ FS.listTree(".coverage_data", function (name, stat) {
             console.log("        </tr>");
             console.log("    </thead>");
             console.log("    <tbody>");
-            Object.forEach(coverage.files, function (file, path) {
+            Object.keys(coverage.files).forEach(function (path) {
+                var file = coverage.files[path];
                 path = FS.relativeFromDirectory(__dirname, path);
                 if (/^spec/.test(path))
                     return;

--- a/fs-mock.js
+++ b/fs-mock.js
@@ -4,7 +4,7 @@ var Boot = require("./fs-boot");
 var Common = require("./fs-common");
 var BufferStream = require("./buffer-stream");
 var Reader = require("./reader");
-var Set = require("collections/set");
+var Set = require("es6-set");
 
 module.exports = MockFs;
 

--- a/http-apps.js
+++ b/http-apps.js
@@ -39,7 +39,6 @@
  * @module
  */
 
-require("collections/shim");
 var Q = require("q");
 var HTTP = require("./http");
 var FS = require("./fs");

--- a/http-apps/negotiate.js
+++ b/http-apps/negotiate.js
@@ -18,13 +18,12 @@ function negotiate(request, types, header) {
  * @returns {App}
  */
 exports.Method = function (methods, methodNotAllowed) {
-    var keys = Object.keys(methods);
     if (!methodNotAllowed)
         methodNotAllowed = Status.methodNotAllowed;
     return function (request) {
         var method = request.method;
-        if (Object.has(keys, method)) {
-            return Object.get(methods, method)(request);
+        if (Object.prototype.hasOwnProperty.call(methods, method) !== -1) {
+            return methods[method](request);
         } else {
             return methodNotAllowed(request);
         }
@@ -41,7 +40,7 @@ var Negotiator = function (requestHeader, responseHeader, respond) {
             var type = MimeParse.bestMatch(keys, accept);
             request.terms = request.terms || {};
             request.terms[responseHeader] = type;
-            if (Object.has(keys, type)) {
+            if (keys.indexOf(type) !== -1) {
                 return Q.when(types[type](request), function (response) {
                     if (
                         respond !== null &&

--- a/http-apps/route.js
+++ b/http-apps/route.js
@@ -85,10 +85,10 @@ exports.Branch = function (paths, notFound) {
         var path = request.pathInfo.slice(1);
         var parts = path.split("/");
         var part = decodeURIComponent(parts.shift());
-        if (Object.has(paths, part)) {
+        if (hasOwnProperty.call(paths, part)) {
             request.scriptName = request.scriptName + part + "/";
             request.pathInfo = path.slice(part.length);
-            return Object.get(paths, part)(request, response);
+            return paths[part](request, response);
         }
         return notFound(request, response);
     };

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "url": "http://github.com/kriskowal/q-io.git"
   },
   "dependencies": {
-    "q": "^1.0.1",
-    "qs": "^1.2.1",
-    "url2": "^0.0.0",
+    "es6-set": "^0.1.1",
     "mime": "^1.2.11",
     "mimeparse": "^0.1.4",
-    "collections": "^0.2.0"
+    "q": "^1.0.1",
+    "qs": "^1.2.1",
+    "url2": "^0.0.0"
   },
   "devDependencies": {
     "jshint": "^0.9.1",


### PR DESCRIPTION
Since [collections module](http://collectionsjs.com) modifies native objects, it's only good
to be used as a top dependency of an application and not modules that
it's using.

The problem is that this will conflict if native objects has been
modified by another module, let's say something like [sugar](http://sugarjs.com) or just
another version of collections. When you have two of these being used in
your app, you might be in trouble, where some code depends on a
behaviour of a method implemented by one module but actually the method
had been silently overriden by another module having a different
behaviour.
