### PR TITLE
Add timeout option to the http.request()

### DIFF
--- a/http.js
+++ b/http.js
@@ -337,6 +337,12 @@ exports.request = function (request) {
             deferred.reject(error);
         });
 
+        if (request.timeout) {
+            _request.setTimeout(request.timeout, function() {
+                _request.abort();
+            });
+        }
+
         Q.when(request.body, function (body) {
             var end, done;
             if (body) {


### PR DESCRIPTION
So we could set time on every `http.request()` call:

``` js
var http = require('q-io/http');

http.request({
    method: 'get',
    hostname: 'ya.ru',
    path: '/',
    timeout: 50
}).done();
```
