### PR TITLE
Implements buffer decoding for HTTP.read

### DIFF
--- a/http.js
+++ b/http.js
@@ -10,6 +10,8 @@ var HTTPS = require("https"); // node
 var URL = require("url2"); // node
 var Q = require("q");
 var Reader = require("./reader");
+var iconv = require("iconv-lite");
+var stripBom = require('strip-bom');
 
 /**
  * @param {respond(request Request)} respond a JSGI responder function that
@@ -385,7 +387,18 @@ exports.read = function (request, qualifier) {
             error.response = response;
             throw error;
         }
-        return Q.post(response.body, 'read', []);
+        return Q.post(response.body, 'read', []).then(function (data) {
+            var contentType, match, charset;
+
+            if (Buffer.isBuffer(data)) {
+                contentType = response.headers['content-type'],
+                match = contentType.match(/charset=([a-z0-9-]+)/i),
+                charset = match ? match[1] : 'utf8';
+                return iconv.decode(data, charset);
+            }
+
+            return stripBom(data);
+        });
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "url2": "^0.0.0",
     "mime": "^1.2.11",
     "mimeparse": "^0.1.4",
-    "collections": "^0.2.0"
+    "collections": "^0.2.0",
+    "iconv-lite": "0.4.8",
+    "strip-bom": "^1.0.0"
   },
   "devDependencies": {
     "jshint": "^0.9.1",


### PR DESCRIPTION
When HTTP responses arrive as buffers there is no safe way for the user
of HTTP.read to determine the buffer encoding.

The read method however can use the `Content-Type` header to determine
content encoding and convert the respose to string safely. This change
makes read behave according to the API docs, which state that read()
returns a string.

Introduces dependencies on iconv-lite and strip-bom.
