### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
     "mail": "kris@cixar.com",
     "url": "http://github.com/kriskowal/q-io/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/kriskowal/q-io/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/kriskowal/q-io.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
