### PR TITLE
Validates the extracted charset value from the header

### DIFF
--- a/http.js
+++ b/http.js
@@ -11,7 +11,6 @@ var URL = require("url2"); // node
 var Q = require("q");
 var Reader = require("./reader");
 var iconv = require("iconv-lite");
-var stripBom = require('strip-bom');
 
 /**
  * @param {respond(request Request)} respond a JSGI responder function that
@@ -393,11 +392,11 @@ exports.read = function (request, qualifier) {
             if (Buffer.isBuffer(data)) {
                 contentType = response.headers['content-type'] || '',
                 match = contentType.match(/charset=([a-z0-9-]+)/i),
-                charset = match ? match[1] : 'utf8';
+                charset = match && iconv.encodingExists(match[1]) ? match[1] : 'utf8';
                 return iconv.decode(data, charset);
             }
 
-            return stripBom(data);
+            return data;
         });
     });
 };

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "mime": "^1.2.11",
     "mimeparse": "^0.1.4",
     "collections": "^0.2.0",
-    "iconv-lite": "^0.4.8",
-    "strip-bom": "^1.0.0"
+    "iconv-lite": "^0.4.9"
   },
   "devDependencies": {
     "jshint": "^0.9.1",


### PR DESCRIPTION
Uses the encodingExists() method iconv-lite provides to prevent
exceptions in case of unexpected header values. Fallback is UTF-8. Also,
iconv-lite does its own BOM stripping, so the dependency on strip-bom
becomes superfluous.
