### PR TITLE
Prevents newline conversion for spec fixtures on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+spec/**/*.txt -crlf


### PR DESCRIPTION
Exempt spec fixture text files from newline conversion so tests don't
fail needlessly on Windows.

Checking out on Windows used to break tests because some of them read text files from disk and compared their contents byte-by-byte with an expected value. Telling git to leave the text files alone fixes these errors.
