### PR TITLE
Encode the path fragment of a normalized request

### DIFF
--- a/http.js
+++ b/http.js
@@ -272,7 +272,8 @@ exports.normalizeRequest = function (request) {
         request.host = request.hostname + (defaultPort ? "" : ":" + request.port);
     }
     request.headers.host = request.headers.host || request.host;
-    request.path = request.path || "/";
+    request.path = encodeURI(request.path || "/");
+
     return request;
 };
 

--- a/http.js
+++ b/http.js
@@ -272,7 +272,13 @@ exports.normalizeRequest = function (request) {
         request.host = request.hostname + (defaultPort ? "" : ":" + request.port);
     }
     request.headers.host = request.headers.host || request.host;
-    request.path = encodeURI(request.path || "/");
+
+    request.path = request.path || "/";
+
+    // Making sure we do not double encode a string
+    // This will still fail for arbitrary depth encodings
+    request.path = encodeURI(
+        decodeURI(request.path));
 
     return request;
 };

--- a/spec/http/normalize-request-spec.js
+++ b/spec/http/normalize-request-spec.js
@@ -201,4 +201,39 @@ describe("request normalization", function () {
         });
     });
 
+    it("must url encode the request's querystring", function () {
+        var request = normalizeRequest("http://google.com/search?q=entrées");
+        expect(request).toEqual({
+            url: "http://google.com/search?q=entrées",
+            method: "GET",
+            ssl: false,
+            host: "google.com",
+            hostname: "google.com",
+            port: 80,
+            path: "/search?q=entr%C3%A9es",
+            headers: { host: "google.com" }
+        });
+    });
+
+    it("must url encode the request's path", function () {
+        var request = normalizeRequest("http://google.com/é");
+        expect(request).toEqual({
+            url: "http://google.com/é",
+            method: "GET",
+            ssl: false,
+            host: "google.com",
+            hostname: "google.com",
+            port: 80,
+            path: "/%C3%A9",
+            headers: { host: "google.com" }
+        });
+    });
+
+    it("must url encode the request's path (more characters)", function () {
+        var charactersToEncode = "èÈàÀêÊÀùÙçÇÈîôôÇöä";
+        var request = normalizeRequest(
+          "http://google.com/search?q=" + charactersToEncode);
+        var decodedPath = decodeURIComponent(request.path);
+        expect(decodedPath).toEqual("/search?q=" + charactersToEncode);
+    });
 });

--- a/spec/http/normalize-request-spec.js
+++ b/spec/http/normalize-request-spec.js
@@ -232,8 +232,15 @@ describe("request normalization", function () {
     it("must url encode the request's path (more characters)", function () {
         var charactersToEncode = "èÈàÀêÊÀùÙçÇÈîôôÇöä";
         var request = normalizeRequest(
-          "http://google.com/search?q=" + charactersToEncode);
+            "http://google.com/search?q=" + charactersToEncode);
         var decodedPath = decodeURIComponent(request.path);
         expect(decodedPath).toEqual("/search?q=" + charactersToEncode);
+    });
+
+    it("must not double url encode a request", function () {
+        var uri = "http://google.com/search?q=entr%C3%A9es";
+        var request = normalizeRequest(uri);
+        var decodedPath = decodeURIComponent(request.path);
+        expect(request.path).toEqual("/search?q=entr%C3%A9es");
     });
 });


### PR DESCRIPTION
So I hit this issue crawling some images on a cooking website. The http request was returning a 404, while the image was correctly served.

This returns a 404

``` js
var http = require('q-io/http');
var uri = 
  "http://www.coupdepouce.com/img/photos/biz/CoupDePouce/recettes_non_importees/Entrées/mini-pizzas410.jpg";
http.read(uri).then(console.log).catch(console.log);
```

While using this uri instead returns the right result

``` js
var http = require('q-io/http');
var uri = 
 "http://www.coupdepouce.com/img/photos/biz/CoupDePouce/recettes_non_importees/Entr%C3%A9es/mini-pizzas410.jpg";
http.read(uri).then(console.log).catch(console.log);
```
