### PR TITLE
Fix incorrect version check

### DIFF
--- a/writer.js
+++ b/writer.js
@@ -13,7 +13,7 @@ var Q = require("q");
 module.exports = Writer;
 
 var version = process.versions.node.split('.');
-var supportsFinish = version[0] >= 0 && version[1] >= 10;
+var supportsFinish = version[0] >= 1 || version[1] >= 10;
 
 function Writer(_stream, charset) {
     var self = Object.create(Writer.prototype);


### PR DESCRIPTION
As it stands, the version check will ensure that the major version is non-negative _and_ that the minor version is at least 10.  Current versions, with major version 4 or 5 but single-digit minor versions, are not matched by this.  Instead we can check whether the major version is at least 1 _or_ the minor version is at least 10, assuming in the latter case that the major version cannot be less than 0 so we don't have to check for that.

This fixes #149 except on _very_ old versions of node.
