### PR TITLE
Fix incorrect version check

### DIFF
--- a/node/writer.js
+++ b/node/writer.js
@@ -13,7 +13,7 @@ var Q = require("q");
 module.exports = Writer;
 
 var version = process.versions.node.split('.');
-var supportsFinish = version[0] >= 0 && version[1] >= 10;
+var supportsFinish = version[0] >= 1 || version[1] >= 10;
 
 function Writer(_stream, charset) {
     var self = Object.create(Writer.prototype);


### PR DESCRIPTION
This is a cherry-pick of commit 061284b473ec80dfe4c891d5de4b7b330da2a187 
by Martin Gagern to fix #149 

The original commit message is:

As it stands, the version check will ensure that the major version is
non-negative AND that the minor version is at least 10.  Current versions,
with major version 4 or 5 but single-digit minor versions, are not matched
by this.  Instead we can check whether the major version is at least 1 OR
the minor version is at least 10, assuming in the latter case that the major
version cannot be less than 0 so we don't have to check for that.
