### PR TITLE
fix empty  second request due BufferStream chunks reference colateral

### DIFF
--- a/buffer-stream.js
+++ b/buffer-stream.js
@@ -22,7 +22,7 @@ BufferStream.prototype.forEach = function (write, thisp) {
     var self = this;
     var chunks = self._chunks;
     return Q.fcall(function () {
-        chunks.splice(0, chunks.length).forEach(write, thisp);
+        chunks.forEach(write, thisp);
     });
 };
 

--- a/buffer-stream.js
+++ b/buffer-stream.js
@@ -13,7 +13,7 @@ function BufferStream(chunks, charset) {
         chunks = [chunks];
     }
     this._charset = charset;
-    this._chunks = chunks;
+    this._chunks = chunks.slice(0); // Clone to avoid unexpected side effect
     this._close = Q.defer();
     this.closed = this._close.promise;
 }
@@ -22,7 +22,7 @@ BufferStream.prototype.forEach = function (write, thisp) {
     var self = this;
     var chunks = self._chunks;
     return Q.fcall(function () {
-        chunks.forEach(write, thisp);
+        chunks.splice(0, chunks.length).forEach(write, thisp);
     });
 };
 

--- a/buffer-stream.js
+++ b/buffer-stream.js
@@ -13,7 +13,7 @@ function BufferStream(chunks, charset) {
         chunks = [chunks];
     }
     this._charset = charset;
-    this._chunks = chunks.slice(0); // Clone to avoid unexpected side effect
+    this._chunks = chunks;
     this._close = Q.defer();
     this.closed = this._close.promise;
 }

--- a/fs-mock.js
+++ b/fs-mock.js
@@ -127,7 +127,7 @@ MockFs.prototype.open = function (path, flags, charset, options) {
                 );
             } else {
                 // Clone chunks to avoid side effect
-                var bufferChunks = fileNode._chunks.slice(0);
+                var bufferChunks = fileNode._chunks.slice();
                 return new BufferStream(bufferChunks, charset);
             }
         }

--- a/fs-mock.js
+++ b/fs-mock.js
@@ -91,7 +91,7 @@ MockFs.prototype.open = function (path, flags, charset, options) {
         if (!binary) {
             charset = charset || "utf-8";
         }
-        if (write || append) {
+        if (write || append) { // write
             if (!node._entries[base]) {
                 node._entries[base] = new FileNode(this);
                 if ("mode" in options) {
@@ -126,7 +126,9 @@ MockFs.prototype.open = function (path, flags, charset, options) {
                     charset
                 );
             } else {
-                return new BufferStream(fileNode._chunks, charset);
+                // Clone chunks to avoid side effect
+                var bufferChunks = fileNode._chunks.slice(0);
+                return new BufferStream(bufferChunks, charset);
             }
         }
     });


### PR DESCRIPTION
fix empty File.chunks on MockFs second request due BufferStream splice on reference.

Using following example with Joey, "a/b/d.txt" get only served once:
See example https://github.com/montagejs/joey/pull/16

```
var joey = require("../joey");
var MockFs = require("q-io/fs-mock");

var mockFs = MockFs({
    "a": {
        "b": {
            "c.txt": "Content of a/b/c.txt"
        }
    },
    "a/b/d.txt": new Buffer("Content of a/b/d.txt", "utf-8")
})

var server = joey // Hi.
  .fileTree('/', {fs: mockFs}) // Use mockFs
  .listen(8888) // start the server
  .then(function (server) { // when it has started
      // let us know
      console.log("Listening on", server.address().port);
  }).done();

```

